### PR TITLE
Set default log level to info

### DIFF
--- a/kale/util/initial-config.yaml
+++ b/kale/util/initial-config.yaml
@@ -49,7 +49,7 @@ daemon_ssl:
 logging: &logging
   log_stdout: False  # If True, outputs to stdout instead of a file
   log_filename: "log/debug.log"
-  log_level: "WARNING"  # Can be CRITICAL, ERROR, WARNING, INFO, DEBUG, NOTSET
+  log_level: "INFO"  # Can be CRITICAL, ERROR, WARNING, INFO, DEBUG, NOTSET
   log_maxfilesrotation: 7 #  Max files in rotation. Default value 7 if the key is not set
 
 harvester:


### PR DESCRIPTION
Most people farming chia forks are using some kind of log parsing for farm health, such as Farmr. These require log level info for some useful information.